### PR TITLE
disable minimization

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,9 @@ var path = require('path');
 
 module.exports = {
   entry: './src/index.js',
+  optimization: {
+    minimize: false // disable minimazation since it's a library
+  },
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'highlighter.js',


### PR DESCRIPTION
Since it's a library it'll be bundled into whatever project is using it.

There's a bunch of other flags detailed in
https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a
but I think minimize is all we'll need to set.