### PR TITLE
Disable flattening highlights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openstax/highlighter",
-  "version": "1.2.0-beta.4",
+  "version": "1.2.0-beta.5",
   "main": "dist/index.js",
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "current": "node -e \"console.log(require('./package.json').version)\"",
     "clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "current": "node -e \"console.log(require('./package.json').version)\"",
     "clean": "rm -rf dist",
-    "build": "tsc -m es6 --outDir dist",
+    "build": "tsc --outDir dist",
     "build:clean": "npm-run-all clean build",
     "deploy:examples": "gh-pages -d examples",
     "lint": "npm-run-all lint:js lint:ts lint:ts-types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/highlighter",
-  "version": "1.1.9",
+  "version": "1.2.0-beta.4",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
@@ -8,8 +8,6 @@
     "clean": "rm -rf dist",
     "build": "tsc -m es6 --outDir dist",
     "build:clean": "npm-run-all clean build",
-    "clean": "rm -rf dist",
-    "current": "node -e \"console.log(require('./package.json').version)\"",
     "deploy:examples": "gh-pages -d examples",
     "lint": "npm-run-all lint:js lint:ts lint:ts-types",
     "lint:js": "eslint src/**/*.js",

--- a/src/injectHighlightWrappers.ts
+++ b/src/injectHighlightWrappers.ts
@@ -50,7 +50,7 @@ export default function injectHighlightWrappers(highlight: Highlight, options: I
 function normalizeHighlights(highlights: Node[]) {
   let normalizedHighlights;
 
-  flattenNestedHighlights(highlights);
+  //flattenNestedHighlights(highlights);
   mergeSiblingHighlights(highlights);
 
   // omit removed nodes
@@ -225,6 +225,7 @@ function refineRangeBoundaries(range: Range) {
  * Note: this method changes input highlights - their order and number after calling this method may change.
  * @param {Array} highlights - highlights to flatten.
  */
+// @ts-ignore
 function flattenNestedHighlights(highlights: Node[]) {
   let again;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "alwaysStrict": true,
     "strict": true,
     "declaration": true,
-    "module": "es6",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true
   },


### PR DESCRIPTION
disabling this for now because rex has a use case for nested highlights when highlighting search results. 

would not be opposed to flattening for a particular highlight object, but this is handling any highlights on the page and that is breaking things. not spending the time right now to figure out how to do it better.