### PR TITLE
find clicked highlight by navigating up the DOM

### DIFF
--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -1,4 +1,4 @@
-import dom from './dom';
+import dom, { isHtmlElement } from './dom';
 import Highlight, { FOCUS_CSS } from './Highlight';
 import injectHighlightWrappers, { DATA_ATTR, DATA_ID_ATTR } from './injectHighlightWrappers';
 import { rangeContentsString } from './rangeContents';
@@ -86,23 +86,25 @@ export default class Highlighter {
     }
 
     if (selection.isCollapsed) {
-      this.onClick(ev.target as HTMLElement);
+      this.onClick(ev.target);
     } else {
       this.onSelect(selection);
     }
   }
 
-  private onClick(el: HTMLElement): void {
+  private onClick(el: any): void {
     const { onClick } = this.options;
     if (!onClick) { return; }
 
-    const hlEl = dom(el).closest('[' + DATA_ATTR + ']');
-    if (hlEl) {
-      const id = hlEl.getAttribute(DATA_ID_ATTR) as string;
-      const highlight = this.highlights[id];
-      if (highlight) {
-        onClick(highlight);
-        return;
+    if (isHtmlElement(el)) {
+      const hlEl = dom(el).closest('[' + DATA_ATTR + ']');
+      if (hlEl) {
+        const id = hlEl.getAttribute(DATA_ID_ATTR) as string;
+        const highlight = this.highlights[id];
+        if (highlight) {
+          onClick(highlight);
+          return;
+        }
       }
     }
     onClick();

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -1,4 +1,4 @@
-import dom, { isHtmlElement } from './dom';
+import dom from './dom';
 import Highlight, { FOCUS_CSS } from './Highlight';
 import injectHighlightWrappers, { DATA_ATTR, DATA_ID_ATTR } from './injectHighlightWrappers';
 import { rangeContentsString } from './rangeContents';
@@ -92,12 +92,13 @@ export default class Highlighter {
     }
   }
 
-  private onClick(el: any): void {
+  private onClick(target: any): void {
     const { onClick } = this.options;
     if (!onClick) { return; }
 
-    if (isHtmlElement(el)) {
-      const hlEl = dom(el).closest('[' + DATA_ATTR + ']');
+    const el = dom(target);
+    if (el.isHtmlElement) {
+      const hlEl = el.closest('[' + DATA_ATTR + ']');
       if (hlEl) {
         const id = hlEl.getAttribute(DATA_ID_ATTR) as string;
         const highlight = this.highlights[id];

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -1,6 +1,6 @@
 import dom from './dom';
 import Highlight, { FOCUS_CSS } from './Highlight';
-import injectHighlightWrappers, { DATA_ATTR, DATA_ID_ATTR } from './injectHighlightWrappers';
+import injectHighlightWrappers, { DATA_ATTR_SELECTOR, DATA_ID_ATTR } from './injectHighlightWrappers';
 import { rangeContentsString } from './rangeContents';
 import removeHighlightWrappers from './removeHighlightWrappers';
 import { snapSelection } from './selection';

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -1,6 +1,6 @@
 import dom from './dom';
 import Highlight, { FOCUS_CSS } from './Highlight';
-import injectHighlightWrappers, { DATA_ATTR_SELECTOR, DATA_ID_ATTR } from './injectHighlightWrappers';
+import injectHighlightWrappers, { DATA_ATTR, DATA_ID_ATTR } from './injectHighlightWrappers';
 import { rangeContentsString } from './rangeContents';
 import removeHighlightWrappers from './removeHighlightWrappers';
 import { snapSelection } from './selection';
@@ -99,7 +99,9 @@ export default class Highlighter {
     if (dom(target).isHtmlElement) {
       target = dom(target);
       while (target.isHtmlElement) {
-        if (target.matches(DATA_ATTR_SELECTOR)) {
+        if (target.el.getAttribute(DATA_ATTR)) {
+          // there may be multiple highlighters active on the same document,
+          // check if the found highlight is known to this instance
           const highlight = this.highlights[target.el.getAttribute(DATA_ID_ATTR)];
           if (highlight) {
             onClick(highlight);

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -96,16 +96,17 @@ export default class Highlighter {
     const { onClick } = this.options;
     if (!onClick) { return; }
 
-    const el = dom(target);
-    if (el.isHtmlElement) {
-      const hlEl = el.closest('[' + DATA_ATTR + ']');
-      if (hlEl) {
-        const id = hlEl.getAttribute(DATA_ID_ATTR) as string;
-        const highlight = this.highlights[id];
-        if (highlight) {
-          onClick(highlight);
-          return;
+    if (dom(target).isHtmlElement) {
+      target = dom(target);
+      while (target.isHtmlElement) {
+        if (target.matches(DATA_ATTR_SELECTOR)) {
+          const highlight = this.highlights[target.el.getAttribute(DATA_ID_ATTR)];
+          if (highlight) {
+            onClick(highlight);
+            return;
+          }
         }
+        target = dom(target.el.parentElement);
       }
     }
     onClick();

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -262,5 +262,16 @@ export default function dom(el: any) {
       }
     },
 
-  };
+    get isHtmlElement(): boolean {
+      return typeof el === 'object'
+        && el !== null
+        && el.nodeType === 1
+        && el.title !== undefined
+        && typeof el.nodeName === 'string'
+        ;
+    },
+  }
 }
+
+export const isHtmlElement = (thing: any): thing is HTMLElement =>
+  dom(thing).isHtmlElement;

--- a/src/injectHighlightWrappers.ts
+++ b/src/injectHighlightWrappers.ts
@@ -4,6 +4,7 @@ import Highlight from './Highlight';
 
 export const TIMESTAMP_ATTR = 'data-timestamp';
 export const DATA_ATTR = 'data-highlighted';
+export const DATA_ATTR_SELECTOR = '[' + DATA_ATTR + ']';
 export const DATA_ID_ATTR = 'data-highlight-id';
 const NODE_TYPE = {
   ELEMENT_NODE: 1,
@@ -326,7 +327,7 @@ function createWrapper(options: any) {
 }
 
 function isHighlight(el: any): el is HTMLElement {
-  return el && el.nodeType === NODE_TYPE.ELEMENT_NODE && el.hasAttribute(DATA_ATTR);
+  return el && el.nodeType === NODE_TYPE.ELEMENT_NODE && el.matches(DATA_ATTR_SELECTOR);
 }
 
 function sortByDepth(arr: Node[], descending: boolean) {

--- a/src/injectHighlightWrappers.ts
+++ b/src/injectHighlightWrappers.ts
@@ -4,6 +4,7 @@ import Highlight from './Highlight';
 
 export const TIMESTAMP_ATTR = 'data-timestamp';
 export const DATA_ATTR = 'data-highlighted';
+export const DATA_ID_ATTR = 'data-highlight-id';
 const NODE_TYPE = {
   ELEMENT_NODE: 1,
   TEXT_NODE: 3,
@@ -64,7 +65,7 @@ function normalizeHighlights(highlights: Node[]) {
 
   normalizedHighlights = unique(normalizedHighlights);
   normalizedHighlights.sort(function(a: Node, b: Node) {
-    if ( !a.compareDocumentPosition) {
+    if (!a.compareDocumentPosition) {
       // support for IE8 and below
       return (a as any).sourceIndex - (b as any).sourceIndex;
     }
@@ -319,7 +320,7 @@ function createWrapper(options: any) {
     span.setAttribute(TIMESTAMP_ATTR, options.timestamp);
   }
   if (options.id) {
-    span.setAttribute('data-id', options.id);
+    span.setAttribute(DATA_ID_ATTR, options.id);
   }
   return span;
 }

--- a/src/removeHighlightWrappers.ts
+++ b/src/removeHighlightWrappers.ts
@@ -1,7 +1,7 @@
 // tslint:disable
 import dom from './dom';
 import Highlight from './Highlight';
-import { DATA_ATTR } from './injectHighlightWrappers';
+import { DATA_ATTR_SELECTOR } from './injectHighlightWrappers';
 
 const NODE_TYPE = {
   ELEMENT_NODE: 1,
@@ -58,10 +58,10 @@ function removeHighlightElement(element: HTMLElement) {
  * @returns {Array} - array of highlights.
  */
 function getHighlights(container: HTMLElement) {
-  const nodeList = container.querySelectorAll('[' + DATA_ATTR + ']'),
+  const nodeList = container.querySelectorAll(DATA_ATTR_SELECTOR),
     highlights = Array.prototype.slice.call(nodeList);
 
-  if (container.hasAttribute(DATA_ATTR)) {
+  if (container.matches(DATA_ATTR_SELECTOR)) {
     highlights.push(container);
   }
 

--- a/src/removeHighlightWrappers.ts
+++ b/src/removeHighlightWrappers.ts
@@ -1,8 +1,7 @@
 // tslint:disable
 import dom from './dom';
 import Highlight from './Highlight';
-
-export const DATA_ATTR = 'data-highlighted';
+import { DATA_ATTR } from './injectHighlightWrappers';
 
 const NODE_TYPE = {
   ELEMENT_NODE: 1,

--- a/src/serializationStrategies/XpathRangeSelector/xpath.ts
+++ b/src/serializationStrategies/XpathRangeSelector/xpath.ts
@@ -1,5 +1,5 @@
 // tslint:disable
-import {DATA_ATTR} from '../../injectHighlightWrappers';
+import { DATA_ATTR } from '../../injectHighlightWrappers';
 
 const findNonTextChild = (node: Node) => Array.prototype.find.call(node.childNodes,
   (node: Node) => node.nodeType === Node.ELEMENT_NODE && !isTextHighlight(node)
@@ -51,10 +51,10 @@ const resolveTextHighlightsToTextOffset = (element: Node, offset: number, contai
   // want to contiue using element offset if possible
   if (isElement(element) && isTextOrTextHighlight(element.childNodes[offset])) {
     return recurseBackwardsThroughText(element.childNodes[offset], container, 0);
-  // however, if the element, is a highlgiht, then we should float
+    // however, if the element, is a highlgiht, then we should float
   } else if (isTextHighlight(element)) {
     return recurseBackwardsThroughText(element, container, getTextLength(element));
-  // preserve the offset if the elment is text
+    // preserve the offset if the elment is text
   } else if (isText(element)) {
     return recurseBackwardsThroughText(element, container, offset);
   } else {


### PR DESCRIPTION
Using the selection api to find the clicked highlight fails if the clicked element for the selection is non-textual like an image.