### PR TITLE
add a `teardown` method to unmount and erase highlights

### DIFF
--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -37,6 +37,11 @@ export default class Highlighter {
     this.getHighlights().forEach(this.erase);
   }
 
+  public teardown = (): void => {
+    this.eraseAll();
+    this.unmount();
+  }
+
   public erase = (highlight: Highlight): void => {
     removeHighlightWrappers(highlight);
     delete this.highlights[highlight.id];
@@ -131,7 +136,7 @@ export default class Highlighter {
         .filter((other: Highlight) => other.intersects(range));
 
       if (highlights.length === 0) {
-        const highlight: Highlight = new Highlight(range, {content: rangeContentsString(range)});
+        const highlight: Highlight = new Highlight(range, { content: rangeContentsString(range) });
         onSelect(highlights, highlight);
       } else {
         onSelect(highlights);

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -136,7 +136,7 @@ export default class Highlighter {
         .filter((other: Highlight) => other.intersects(range));
 
       if (highlights.length === 0) {
-        const highlight: Highlight = new Highlight(range, { content: rangeContentsString(range) });
+        const highlight: Highlight = new Highlight(range, {content: rangeContentsString(range)});
         onSelect(highlights, highlight);
       } else {
         onSelect(highlights);


### PR DESCRIPTION
Tutor had a bug where highlights would remain on the page due to a
mnissed eraseAll call