### PR TITLE
Add support for selecting text with keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-typescript": "^7.1.0",
     "@types/jest": "^23.3.7",
+    "@types/lodash": "^4.14.168",
     "@types/uuid": "^3.4.6",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
@@ -70,6 +71,7 @@
   "dependencies": {
     "@openstax/highlights-client": "0.2.1",
     "change-case": "^4.0.0",
+    "lodash": "^4.17.21",
     "serialize-selection": "^1.1.1",
     "uuid": "^3.3.3"
   }

--- a/src/Highlighter.test.ts
+++ b/src/Highlighter.test.ts
@@ -176,6 +176,10 @@ describe('onSelect', () => {
     e.initEvent('selectionchange', true, true);
     document.dispatchEvent(e);
 
+    const eKeyUp = document.createEvent('Event');
+    eKeyUp.initEvent('keyup', true, true);
+    container.dispatchEvent(eKeyUp);
+
     if (highlight === undefined) {
       expect(highlight).toBeDefined();
     } else {

--- a/src/Highlighter.test.ts
+++ b/src/Highlighter.test.ts
@@ -1,5 +1,6 @@
+import * as lodash from 'lodash';
 import Highlight from './Highlight';
-import Highlighter, { ON_SELECT_DELAY } from './Highlighter';
+import Highlighter from './Highlighter';
 import * as injectHighlightWrappersUtils from './injectHighlightWrappers';
 import * as rangeContents from './rangeContents';
 import * as selection from './selection';
@@ -141,11 +142,16 @@ describe('onSelect', () => {
 
     container.appendChild(node);
 
+    const spyDebounce = jest.spyOn(lodash, 'debounce')
+      .mockImplementation((fn: any) => fn);
+
     // tslint:disable-next-line no-unused-expression
     new Highlighter(
       container,
       {onSelect: (_: Highlight[], newHighlight?: Highlight) => highlight = newHighlight}
     );
+
+    expect(spyDebounce).toHaveBeenCalled();
 
     const inputSelection = new Selection();
     const selectionRange = new Range();
@@ -170,8 +176,6 @@ describe('onSelect', () => {
     e.initEvent('selectionchange', true, true);
     document.dispatchEvent(e);
 
-    jest.runTimersToTime(ON_SELECT_DELAY);
-
     if (highlight === undefined) {
       expect(highlight).toBeDefined();
     } else {
@@ -188,8 +192,13 @@ describe('onSelect', () => {
 
     container.appendChild(node);
 
+    const spyDebounce = jest.spyOn(lodash, 'debounce')
+      .mockImplementation((fn: any) => fn);
+
     // tslint:disable-next-line no-unused-expression
     new Highlighter(container, {onSelect: spyOnSelect});
+
+    expect(spyDebounce).toHaveBeenCalled();
 
     getSelectionSpy.mockImplementation(() => null);
 
@@ -197,19 +206,13 @@ describe('onSelect', () => {
     e.initEvent('selectionchange', true, true);
     document.dispatchEvent(e);
 
-    jest.runTimersToTime(ON_SELECT_DELAY + 100);
-
     expect(spyOnSelect).not.toHaveBeenCalled();
 
     getSelectionSpy.mockImplementation(() => ({ isCollapsed: true }));
 
-    jest.runTimersToTime(ON_SELECT_DELAY + 100);
-
     expect(spyOnSelect).not.toHaveBeenCalled();
 
     getSelectionSpy.mockImplementation(() => ({ isCollapsed: false, type: 'None' }));
-
-    jest.runTimersToTime(ON_SELECT_DELAY + 100);
 
     expect(spyOnSelect).not.toHaveBeenCalled();
   });
@@ -223,8 +226,13 @@ describe('onSelect', () => {
 
     container.appendChild(nodeInside);
 
+    const spyDebounce = jest.spyOn(lodash, 'debounce')
+      .mockImplementation((fn: any) => fn);
+
     // tslint:disable-next-line no-unused-expression
     new Highlighter(container, {onSelect: spyOnSelect});
+
+    expect(spyDebounce).toHaveBeenCalled();
 
     getSelectionSpy.mockImplementation(() => ({ isCollapsed: false, anchorNode: nodeOutside, focusNode: nodeInside }));
 
@@ -232,13 +240,9 @@ describe('onSelect', () => {
     e.initEvent('selectionchange', true, true);
     document.dispatchEvent(e);
 
-    jest.runTimersToTime(ON_SELECT_DELAY + 100);
-
     expect(spyOnSelect).not.toHaveBeenCalled();
 
     getSelectionSpy.mockImplementation(() => ({ isCollapsed: false, anchorNode: nodeInside, focusNode: nodeOutside }));
-
-    jest.runTimersToTime(ON_SELECT_DELAY + 100);
 
     expect(spyOnSelect).not.toHaveBeenCalled();
   });

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -20,6 +20,8 @@ export default class Highlighter {
   public readonly container: HTMLElement;
   private highlights: { [key: string]: Highlight } = {};
   private options: IOptions;
+  private keyUpTimeout: NodeJS.Timeout | null = null;
+  // private selectionTimeout: NodeJS.Timeout | null = null;
 
   constructor(container: HTMLElement, options: IOptions = {}) {
     this.container = container;
@@ -28,10 +30,14 @@ export default class Highlighter {
       ...options,
     };
     this.container.addEventListener('mouseup', this.onMouseup);
+    this.container.addEventListener('keyup', this.onKeyUp);
+    // this.container.addEventListener('selectionchange', this.onSelectionChange);
   }
 
   public unmount(): void {
     this.container.removeEventListener('mouseup', this.onMouseup);
+    this.container.removeEventListener('keyup', this.onKeyUp);
+    // this.container.removeEventListener('selectionchange', this.onSelectionChange);
   }
 
   public eraseAll = (): void => {
@@ -126,6 +132,46 @@ export default class Highlighter {
       this.onSelect(selection);
     }
   }
+
+  private onKeyUp = (ev: KeyboardEvent): void => {
+    if (this.keyUpTimeout) {
+      clearTimeout(this.keyUpTimeout);
+    }
+
+    const selection = this.document.getSelection();
+
+    if (!selection || selection.isCollapsed) {
+      return;
+    }
+
+    if (ev.shiftKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(ev.key)) {
+      this.onSelect(selection);
+    }
+  }
+
+  // private onSelectionChange = (ev: Event): void => {
+  //   if (this.selectionTimeout) {
+  //     clearTimeout(this.selectionTimeout);
+  //   }
+
+  //   const selection = this.document.getSelection();
+
+  //   if (!selection) {
+  //     return;
+  //   }
+
+  //   if (selection.isCollapsed) {
+  //     this.onClick(ev as any);
+  //     return;
+  //   }
+
+  //   this.selectionTimeout = setTimeout(() => {
+  //     const sel = this.document.getSelection();
+  //     if (!sel) { return; }
+
+  //     this.onSelect(sel);
+  //   }, 500);
+  // }
 
   private onClick(event: MouseEvent): void {
     const { onClick } = this.options;

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -6,6 +6,8 @@ import removeHighlightWrappers from './removeHighlightWrappers';
 import { getRange, snapSelection } from './selection';
 import SerializedHighlight from './SerializedHighlight';
 
+export const ON_SELECT_DELAY = 500;
+
 interface IOptions {
   snapTableRows?: boolean;
   snapMathJax?: boolean;
@@ -140,7 +142,7 @@ export default class Highlighter {
       if (!sel) { return; }
 
       this.onSelect(sel);
-    }, 500);
+    }, ON_SELECT_DELAY);
   }
 
   private onClickHandler = (event: MouseEvent): void => {

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -8,6 +8,7 @@ import { getRange, snapSelection } from './selection';
 import SerializedHighlight from './SerializedHighlight';
 
 export const ON_SELECT_DELAY = 500;
+export const ON_SELECTION_CHANGE_DELAY = 250;
 
 interface IOptions {
   snapTableRows?: boolean;
@@ -23,6 +24,8 @@ export default class Highlighter {
   public readonly container: HTMLElement;
   private highlights: { [key: string]: Highlight } = {};
   private options: IOptions;
+  private previousRange: Range | null = null;
+  private isSnapping = false;
 
   constructor(container: HTMLElement, options: IOptions = {}) {
     this.container = container;
@@ -31,15 +34,14 @@ export default class Highlighter {
       ...options,
     };
     this.debouncedOnSelect = debounce(this.onSelect, ON_SELECT_DELAY);
+    this.debouncedOnSelectionChange = debounce(this.onSelectionChange, ON_SELECTION_CHANGE_DELAY);
     this.container.addEventListener('click', this.onClickHandler);
-    document.addEventListener('selectionchange', this.onSelectionChange);
-    document.addEventListener('mouseup', this.snapSelection);
+    document.addEventListener('selectionchange', this.debouncedOnSelectionChange);
   }
 
   public unmount(): void {
     this.container.removeEventListener('click', this.onClickHandler);
-    document.removeEventListener('selectionchange', this.onSelectionChange);
-    document.removeEventListener('mouseup', this.snapSelection);
+    document.removeEventListener('selectionchange', this.debouncedOnSelectionChange);
   }
 
   public eraseAll = (): void => {
@@ -121,29 +123,33 @@ export default class Highlighter {
     return this.container.ownerDocument;
   }
 
-  private snapSelection = (): void => {
-    const selection = this.document.getSelection();
-
-    if (!selection || selection.isCollapsed) {
-      return;
-    }
-
-    snapSelection(selection, this.options);
-  }
-
   // Created in the constructor
   private debouncedOnSelect: () => void = () => undefined;
+
+  // Created in the constructor
+  private debouncedOnSelectionChange: () => void = () => undefined;
 
   private onSelectionChange = (): void => {
     const selection = this.document.getSelection();
 
     if (
-      !selection
+      this.isSnapping
+      || !selection
       || selection.isCollapsed
       || selection.type === 'None'
       || !dom(this.container).contains(selection.anchorNode)
       || !dom(this.container).contains(selection.focusNode)
+      || this.compareRanges(selection ? getRange(selection) : null, this.previousRange)
     ) {
+      return;
+    }
+
+    this.isSnapping = true;
+    const range = snapSelection(selection, this.options);
+    this.isSnapping = false;
+    this.previousRange = range || null;
+
+    if (!range) {
       return;
     }
 
@@ -202,5 +208,13 @@ export default class Highlighter {
         onSelect(highlights);
       }
     }
+  }
+
+  private compareRanges(range1: Range | null, range2: Range | null): boolean {
+    if (range1 === null && range2 === null) { return true; }
+    if (range1 === null && range2) { return false; }
+    if (range2 === null && range1) { return false; }
+    return range1!.compareBoundaryPoints(Range.START_TO_START, range2!) === 0
+      && range1!.compareBoundaryPoints(Range.END_TO_END, range2!) === 0;
   }
 }

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -7,8 +7,7 @@ import removeHighlightWrappers from './removeHighlightWrappers';
 import { getRange, snapSelection } from './selection';
 import SerializedHighlight from './SerializedHighlight';
 
-export const ON_SELECT_DELAY = 500;
-export const ON_SELECTION_CHANGE_DELAY = 250;
+export const ON_SELECT_DELAY = 300;
 
 interface IOptions {
   snapTableRows?: boolean;
@@ -25,7 +24,6 @@ export default class Highlighter {
   private highlights: { [key: string]: Highlight } = {};
   private options: IOptions;
   private previousRange: Range | null = null;
-  private isSnapping = false;
 
   constructor(container: HTMLElement, options: IOptions = {}) {
     this.container = container;
@@ -34,14 +32,17 @@ export default class Highlighter {
       ...options,
     };
     this.debouncedOnSelect = debounce(this.onSelect, ON_SELECT_DELAY);
-    this.debouncedOnSelectionChange = debounce(this.onSelectionChange, ON_SELECTION_CHANGE_DELAY);
     this.container.addEventListener('click', this.onClickHandler);
-    document.addEventListener('selectionchange', this.debouncedOnSelectionChange);
+    document.addEventListener('selectionchange', this.onSelectionChange);
+    this.container.addEventListener('keyup', this.snapSelection);
+    this.container.addEventListener('mouseup', this.snapSelection);
   }
 
   public unmount(): void {
     this.container.removeEventListener('click', this.onClickHandler);
-    document.removeEventListener('selectionchange', this.debouncedOnSelectionChange);
+    document.removeEventListener('selectionchange', this.onSelectionChange);
+    this.container.removeEventListener('keyup', this.snapSelection);
+    this.container.removeEventListener('mouseup', this.snapSelection);
   }
 
   public eraseAll = (): void => {
@@ -123,33 +124,30 @@ export default class Highlighter {
     return this.container.ownerDocument;
   }
 
-  // Created in the constructor
-  private debouncedOnSelect: () => void = () => undefined;
+  private snapSelection = () => {
+    const selection = this.document.getSelection();
+
+    if (!selection || selection.isCollapsed) {
+      return;
+    }
+
+    return snapSelection(selection, this.options);
+  }
 
   // Created in the constructor
-  private debouncedOnSelectionChange: () => void = () => undefined;
+  private debouncedOnSelect: () => void = () => undefined;
 
   private onSelectionChange = (): void => {
     const selection = this.document.getSelection();
 
     if (
-      this.isSnapping
-      || !selection
+      !selection
       || selection.isCollapsed
       || selection.type === 'None'
       || !dom(this.container).contains(selection.anchorNode)
       || !dom(this.container).contains(selection.focusNode)
       || this.compareRanges(selection ? getRange(selection) : null, this.previousRange)
     ) {
-      return;
-    }
-
-    this.isSnapping = true;
-    const range = snapSelection(selection, this.options);
-    this.isSnapping = false;
-    this.previousRange = range || null;
-
-    if (!range) {
       return;
     }
 
@@ -191,7 +189,8 @@ export default class Highlighter {
       return;
     }
 
-    const range = getRange(selection);
+    const range = this.snapSelection();
+    this.previousRange = range || null;
 
     if (onSelect && range) {
       const highlights: Highlight[] = Object.values(this.highlights)

--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -31,18 +31,19 @@ export default class Highlighter {
       className: 'highlight',
       ...options,
     };
+    this.debouncedSnapSelection = debounce(this.snapSelection, ON_SELECT_DELAY);
     this.debouncedOnSelect = debounce(this.onSelect, ON_SELECT_DELAY);
     this.container.addEventListener('click', this.onClickHandler);
     document.addEventListener('selectionchange', this.onSelectionChange);
-    this.container.addEventListener('keyup', this.snapSelection);
-    this.container.addEventListener('mouseup', this.snapSelection);
+    this.container.addEventListener('keyup', this.debouncedOnSelect);
+    this.container.addEventListener('mouseup', this.onSelect);
   }
 
   public unmount(): void {
     this.container.removeEventListener('click', this.onClickHandler);
     document.removeEventListener('selectionchange', this.onSelectionChange);
-    this.container.removeEventListener('keyup', this.snapSelection);
-    this.container.removeEventListener('mouseup', this.snapSelection);
+    this.container.removeEventListener('keyup', this.debouncedOnSelect);
+    this.container.removeEventListener('mouseup', this.onSelect);
   }
 
   public eraseAll = (): void => {
@@ -135,6 +136,9 @@ export default class Highlighter {
   }
 
   // Created in the constructor
+  private debouncedSnapSelection: () => void = () => undefined;
+
+  // Created in the constructor
   private debouncedOnSelect: () => void = () => undefined;
 
   private onSelectionChange = (): void => {
@@ -151,7 +155,7 @@ export default class Highlighter {
       return;
     }
 
-    this.debouncedOnSelect();
+    this.debouncedSnapSelection();
   }
 
   private onClickHandler = (event: MouseEvent): void => {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -14,6 +14,18 @@ export const getRange = (selection: Selection): Range => {
   return range;
 };
 
+const getDirection = (selection: Selection): 'forward' | 'backward' => {
+  const anchorNode = selection.anchorNode;
+  const anchorOffset = selection.anchorOffset;
+  const range = getRange(selection);
+
+  if (anchorNode !== range.startContainer || anchorOffset !== range.startOffset) {
+    return 'backward';
+  }
+
+  return 'forward';
+};
+
 interface IOptions {
   snapTableRows?: boolean;
   snapMathJax?: boolean;
@@ -21,6 +33,7 @@ interface IOptions {
 }
 
 export const snapSelection = (selection: Selection, options: IOptions): Range | undefined => {
+  const selectionDirection = getDirection(selection);
   const range = getRange(selection);
 
   if (!range) {
@@ -92,6 +105,16 @@ export const snapSelection = (selection: Selection, options: IOptions): Range | 
         gobbleForward();
       }
     }
+  }
+
+  if (selectionDirection === 'backward') {
+    // https://stackoverflow.com/a/10705853
+    const endRange = range.cloneRange();
+    endRange.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(endRange);
+    selection.extend(range.startContainer, range.startOffset);
+    return range;
   }
 
   selection.removeAllRanges();

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.7.tgz#77f9a4332ccf8db680a31818ade3ee454c831a79"
   integrity sha512-N0p6mHrS0RHC3A9hHN4QH1RM2fGSb2E8rt6ONEK5xKSnyKtn/JAhr1VritkCn6cdyDBephVB80THqJGWzK8FAw==
 
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/node@*":
   version "12.12.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
@@ -3470,6 +3475,11 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
Currently, we are listening only to `mouseup` event so this is why selection text in caret browsing (F7 in Firefox) does not work.

This PR contains 2 possible solutions.
1. Add an additional listener for `keyup` and fire onSelect only for specific keys (shift + arrows)
2. Replace current listener with new one `selectionchange` - it is in an experimental state (https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event) but seems to be supported by most of the browsers. However, implementation from this PR seems to doesn't work - I think it might be related to bundling / wrong target version from tsconfig.
I didn't spent a lot of time figuring what may be wrong, because I would like your opinion on this - should we use an experimental approach?

UPDATE:
We've switched to `selectionchange` and ended up with listening to `keyup` and `mouseup` for snapping selection and then additionally snap selection in `onSelect` function (possibly for mobile devices). 