### PR TITLE
Don't reassign startContainer to null

### DIFF
--- a/src/injectHighlightWrappers.ts
+++ b/src/injectHighlightWrappers.ts
@@ -249,7 +249,7 @@ function refineRangeBoundaries(range: Range) {
     }
   } else if (range.startOffset < startContainer.childNodes.length) {
     startContainer = startContainer.childNodes.item(range.startOffset);
-  } else {
+  } else if (startContainer.nextSibling) {
     startContainer = startContainer.nextSibling as Node;
   }
 


### PR DESCRIPTION
Fixes bug that prevents displaying a highlight that starts on a captionless `img` in Firefox